### PR TITLE
fix versioning

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Quadrilateral",
     "description": "A keyboard based window organizer for ChromeOS.",
-    "version": "2.0.2",
+    "version": "2.0.1",
     "manifest_version": 3,
     "icons": {
         "16": "icons/icon16.png",

--- a/src/src/version_history.html
+++ b/src/src/version_history.html
@@ -13,10 +13,7 @@ latest and greatest version of Quadrilateral, <b>version 2.0.2</b>.
 
 <h2>Version History</h2>
 <ul>
-  <li>2.0.2 - Bump version numbers</li>
-  <li>2.0.1 - Updated documentation to ensure commands names matched. Not
-uploaded to the Chrome Web Store because of a documentation miss. In a
-documentation release no less!
+  <li>2.0.1 - Updated documentation to ensure commands names matched.
   </li>
   <li>2.0.0 - Renamed all the commands for easier maintainence down the
 road. This is a breaking change for upgrades, so, semantic versioning suggests


### PR DESCRIPTION
v2.0.1 wasn't actually released to GitHub so we can use that version number. There's probably a cherry pick reversion we could have done, but, sometimes this is faster.