### PR TITLE
Fix version number in the version history.

### DIFF
--- a/src/src/version_history.html
+++ b/src/src/version_history.html
@@ -9,7 +9,7 @@
 <br>
 
 If you're seeing these release notes, it means that you just upgraded to the
-latest and greatest version of Quadrilateral, <b>version 2.0.2</b>.
+latest and greatest version of Quadrilateral, <b>version 2.0.1</b>.
 
 <h2>Version History</h2>
 <ul>


### PR DESCRIPTION
As part of the 2.0.1 to 2.0.2 and back, missed this. 