### PR TITLE
Fix Halves - Top and Halves - Bottom for multi-monitor

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Quadrilateral",
     "description": "A keyboard based window organizer for ChromeOS.",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "manifest_version": 3,
     "icons": {
         "16": "icons/icon16.png",

--- a/src/src/background.js
+++ b/src/src/background.js
@@ -162,7 +162,8 @@ async function updateWindowPos(command){
         updateTop = displayInfo[displayInfoCount].workArea.top;
       }
       else if (command == "15-halves-bottom"){
-        updateTop = parseInt(height/2);
+      updateTop = displayInfo[displayInfoCount].workArea.top + 
+                  parseInt(height/2);
       }
     }
     else if (command == "16-halves-left" ||

--- a/src/src/readme.html
+++ b/src/src/readme.html
@@ -41,7 +41,7 @@ Here's the author's configuration:
 <ul>
   <li>Thirds - Left: Ctrl + Shift + 4</li>
   <li>Thirds - Center: Ctrl + Shift + 5</li>
-  <li>Thirds - Right (Right 1/3rd: Ctrl + Shift + 6</li>
+  <li>Thirds - Right: Ctrl + Shift + 6</li>
   <li>Sixths - Top Left: Ctrl + Shift + 1</li>
   <li>Sixths - Top Center: Ctrl + Shift + 2</li>
   <li>Sixths - Top Right: Ctrl + Shift + 3</li>
@@ -52,10 +52,8 @@ Here's the author's configuration:
   <li>Quarters - Top Left: Alt + Page Up</li>
   <li>Quarters - Bottom Left: Alt + Page Down</li>
   <li>Quarters - Bottom Right: Alt + End</li>
-  <li>Halves - Top: I don't have this configured as I don't split
-windows this way.</li>
-  <li>Halves - Bottom: I don't have this configured as I don't split
-windows this way.</li>
+  <li>Halves - Top: Alt + Shift + R</li>
+  <li>Halves - Bottom: Alt + Shift + V</li>
   <li>Halves - Left: Alt + Shift + D</li>
   <li>Halves - Right: Alt + Shift + G</li>
 </ul>
@@ -66,6 +64,18 @@ where <a href="https://configure.zsa.io/moonlander/layouts/XYVAx/latest/0">
 keys can be programmed with macros to send these shortcuts when those keys are
 held</a>.
 <br>
+<h2>Why does Chrome say to proceed with caution and that this extension is not
+trusted by Enhanced Safe Browsing?</h2>
+Quadrilateral is the author's first extension and, per Google, <a href="https://support.google.com/chrome_webstore/answer/2664769?visit_id=638478831669693654-98755345&rd=2#10745467&zippy=%2Cinstall-with-enhanced-safe-browsing">
+[for] new developers, it generally takes a few months to become trusted</a>.
+<br>
+<h2>Why doesn't this work for windows from Android or Linux apps on ChromeOS?</h2>
+Quadrilateral is a Chrome extension so it can only manage windows created by
+Chrome.
+<br>
+<h2>Why doesn't this work in Incognito mode?</h2>
+It does! It just needs to be enabled in Extensions > My Extensions > 
+Quadrilateral where "Allow in Incognito" needs to be flipped on.
 <h2>Why does Quadrilateral have Halves - Left and Halves - Right when ChromeOS
 supports these window resize actions natively?</h2>
 Because ChromeOS has an animation associated with it that is slower than

--- a/src/src/version_history.html
+++ b/src/src/version_history.html
@@ -13,6 +13,7 @@ latest and greatest version of Quadrilateral, <b>version 2.1.0</b>.
 
 <h2>Version History</h2>
 <ul>
+  <li>2.1.1 - Fix halves top/bottom on multiple monitors.</li>
   <li>2.1.0 - Now supporting multiple monitors correctly. Also moved a 
 bunch of Javascript promise handling to await/async instead of chaining thens. 
   </li>


### PR DESCRIPTION
Fixed all the multi-monitor cases in 2.1.0 _except_ for 50% top and bottom on external monitors. This fixes that and updates the documentation with additional information.