### PR TITLE
Fix readme.html's missing </a>

### DIFF
--- a/src/src/readme.html
+++ b/src/src/readme.html
@@ -75,7 +75,7 @@ Chrome.
 <br>
 <h2>Why doesn't this work in Incognito mode?</h2>
 It does! It just needs to be enabled in <a href="#" id="extensionsDetailsLink">
-Extensions > My Extensions > Quadrilateral where "Allow in Incognito" needs
+Extensions > My Extensions > Quadrilateral</a> where "Allow in Incognito" needs
 to be flipped on.
 <h2>Why does Quadrilateral have Halves - Left and Halves - Right when ChromeOS
 supports these window resize actions natively?</h2>


### PR DESCRIPTION
The readme had a missing </a> so a bunch of text became a link. No longer.